### PR TITLE
fix: giant value in `space` scale if `positiveValues` has values >= 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utopia-core",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Utopia.fyi fluid calculations",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,7 @@ const clamp = (a: number, min: number = 0, max: number = 1) => Math.min(max, Mat
 const invlerp = (x: number, y: number, a: number) => clamp((a - x) / (y - x))
 const range = (x1: number, y1: number, x2: number, y2: number, a: number) => lerp(x2, y2, invlerp(x1, y1, a))
 const roundValue = (n: number) => Math.round((n + Number.EPSILON) * 10000) / 10000;
+const sortNumberAscending = (a: number, b: number) => Number(a) - Number(b);
 
 // Clamp
 
@@ -256,10 +257,10 @@ const calculateCustomPairs = (config: UtopiaSpaceConfig, sizes: UtopiaSize[]): U
 }
 
 export const calculateSpaceScale = (config: UtopiaSpaceConfig): UtopiaSpaceScale => {
-  const positiveSteps = [...config.positiveSteps || []].sort()
+  const positiveSteps = [...config.positiveSteps || []].sort(sortNumberAscending)
     .map((multiplier, i) => calculateSpaceSize(config, multiplier, i + 1)).reverse();
 
-  const negativeSteps = [...config.negativeSteps || []].sort().reverse()
+  const negativeSteps = [...config.negativeSteps || []].sort(sortNumberAscending).reverse()
     .map((multiplier, i) => calculateSpaceSize(config, multiplier, -1 * (i + 1)));
 
   const sizes = [


### PR DESCRIPTION
I have been waiting for this package for a long time 🤩

## Bug

Invoking 
```ts
calculateSpaceScale({
    minWidth: 320,
    maxWidth: 1240,
    minSize: 18,
    maxSize: 20,
    positiveSteps: [1.5, 2, 3, 4, 6, 8, 10], // RELEVANT LINE
    negativeSteps: [0.75, 0.5, 0.25],
})
```
Produce 
```ts
spaceScale: {
    sizes: [
      {
        label: '3xs',
        minSize: 5,
        maxSize: 5,
        clamp: 'clamp(0.313rem, 0.313rem + 0vi, 0.313rem)',
        clampPx: 'clamp(5px, 5px + 0vi, 5px)'
      },
      {
        label: '2xs',
        minSize: 9,
        maxSize: 10,
        clamp: 'clamp(0.563rem, 0.541rem + 0.109vi, 0.625rem)',
        clampPx: 'clamp(9px, 8.652px + 0.109vi, 10px)'
      },
      {
        label: 'xs',
        minSize: 14,
        maxSize: 15,
        clamp: 'clamp(0.875rem, 0.853rem + 0.109vi, 0.938rem)',
        clampPx: 'clamp(14px, 13.652px + 0.109vi, 15px)'
      },
      {
        label: 's',
        minSize: 18,
        maxSize: 20,
        clamp: 'clamp(1.125rem, 1.082rem + 0.217vi, 1.25rem)',
        clampPx: 'clamp(18px, 17.304px + 0.217vi, 20px)'
      },
      {
        label: 'm',
        minSize: 27,
        maxSize: 30,
        clamp: 'clamp(1.688rem, 1.622rem + 0.326vi, 1.875rem)',
        clampPx: 'clamp(27px, 25.957px + 0.326vi, 30px)'
      },
      {
        label: 'l',
        minSize: 180,// ❌ WRONG: TOO BIG
        maxSize: 200,// ❌WRONG: TOO BIG
        clamp: 'clamp(11.25rem, 10.815rem + 2.174vi, 12.5rem)',
        clampPx: 'clamp(180px, 173.043px + 2.174vi, 200px)'
      },
      {
        label: 'xl',
        minSize: 36,
        maxSize: 40,
        clamp: 'clamp(2.25rem, 2.163rem + 0.435vi, 2.5rem)',
        clampPx: 'clamp(36px, 34.609px + 0.435vi, 40px)'
      },
      {
        label: '2xl',
        minSize: 54,
        maxSize: 60,
        clamp: 'clamp(3.375rem, 3.245rem + 0.652vi, 3.75rem)',
        clampPx: 'clamp(54px, 51.913px + 0.652vi, 60px)'
      },
      {
        label: '3xl',
        minSize: 72,
        maxSize: 80,
        clamp: 'clamp(4.5rem, 4.326rem + 0.87vi, 5rem)',
        clampPx: 'clamp(72px, 69.217px + 0.87vi, 80px)'
      },
 // ....
```

If invoked with 
```ts
calculateSpaceScale({
    minWidth: 320,
    maxWidth: 1240,
    minSize: 18,
    maxSize: 20,
    positiveSteps: [1.5, 2, 3, 4, 6, 8], // Removed 10
    negativeSteps: [0.75, 0.5, 0.25],
})
```
All works as expected.

## Solution
Problem was because 
```ts
[...config.positiveSteps || []].sort()
```
produce 
```
[1.5, 10, 2, 3, 4, 6, 8]
``` 
instead of 
```
[1.5, 2, 3, 4, 6, 8, 10]
```

Created a predicate function that cast to number.
All this because of how `Array.sort()` without predicate function behave

> [From MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#parameters) If omitted, the array elements are converted to strings, then sorted according to each character's Unicode code point value.

