### PR TITLE
[WIP] Added a set of predefined step labels for typescale

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,12 @@ type UtopiaTypeConfig = {
   negativeSteps?: number;
   positiveSteps?: number;
   relativeTo?: UtopiaRelativeTo;
+  labelStyle?: UtopiaLabelStyle;
 }
 
 type UtopiaStep = {
   step: number;
+  label: string;
   minFontSize: number;
   maxFontSize: number;
   wcagViolation: {
@@ -57,6 +59,7 @@ calculateTypeScale({
 // [
 //  {
 //    step: 5,
+//    label: '5',
 //    minFontSize: 44.79,
 //    maxFontSize: 61.04,
 //    wcagViolation: 1200,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "utopia-core",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "utopia-core",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "ISC",
       "devDependencies": {
         "typescript": "^5.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utopia-core",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Utopia.fyi fluid calculations",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -7,13 +7,13 @@ const logObject = (a: unknown) => console.dir(a, { depth: 4 });
 describe('calculateClamp', () => {
 
   test('should generate a single clamp function', () => {
-    const result = calculateClamp({ minSize: 16, maxSize: 32, minWidth: 320, maxWidth: 1240 });    
+    const result = calculateClamp({ minSize: 16, maxSize: 32, minWidth: 320, maxWidth: 1240 });
     const expected = 'clamp(1rem, 0.6522rem + 1.7391vw, 2rem)';
     expect(result).toEqual(expected);
   });
 
   test('should generate a px clamp function', () => {
-    const result = calculateClamp({ minSize: 16, maxSize: 32, minWidth: 320, maxWidth: 1240, usePx: true });    
+    const result = calculateClamp({ minSize: 16, maxSize: 32, minWidth: 320, maxWidth: 1240, usePx: true });
     const expected = 'clamp(16px, 10.4348px + 1.7391vw, 32px)';
     expect(result).toEqual(expected);
   });
@@ -26,7 +26,7 @@ describe('calculateClamp', () => {
 
 
   test('should generate a vi clamp function', () => {
-    const result = calculateClamp({ minSize: 16, maxSize: 32, minWidth: 320, maxWidth: 1240, relativeTo: 'viewport' });    
+    const result = calculateClamp({ minSize: 16, maxSize: 32, minWidth: 320, maxWidth: 1240, relativeTo: 'viewport' });
     const expected = 'clamp(1rem, 0.6522rem + 1.7391vi, 2rem)';
     expect(result).toEqual(expected);
   });
@@ -423,6 +423,7 @@ describe('calculateTypeScale', () => {
     const expected = [
       {
         step: 5,
+        label: '5',
         minFontSize: 44.7898,
         maxFontSize: 61.0352,
         wcagViolation: null,
@@ -430,6 +431,7 @@ describe('calculateTypeScale', () => {
       },
       {
         step: 4,
+        label: '4',
         minFontSize: 37.3248,
         maxFontSize: 48.8281,
         wcagViolation: null,
@@ -437,6 +439,7 @@ describe('calculateTypeScale', () => {
       },
       {
         step: 3,
+        label: '3',
         minFontSize: 31.104,
         maxFontSize: 39.0625,
         wcagViolation: null,
@@ -444,6 +447,7 @@ describe('calculateTypeScale', () => {
       },
       {
         step: 2,
+        label: '2',
         minFontSize: 25.92,
         maxFontSize: 31.25,
         wcagViolation: null,
@@ -451,6 +455,7 @@ describe('calculateTypeScale', () => {
       },
       {
         step: 1,
+        label: '1',
         minFontSize: 21.6,
         maxFontSize: 25,
         wcagViolation: null,
@@ -458,6 +463,7 @@ describe('calculateTypeScale', () => {
       },
       {
         step: 0,
+        label: '0',
         minFontSize: 18,
         maxFontSize: 20,
         wcagViolation: null,
@@ -465,6 +471,7 @@ describe('calculateTypeScale', () => {
       },
       {
         step: -1,
+        label: '-1',
         minFontSize: 15,
         maxFontSize: 16,
         wcagViolation: null,
@@ -472,6 +479,7 @@ describe('calculateTypeScale', () => {
       },
       {
         step: -2,
+        label: '-2',
         minFontSize: 12.5,
         maxFontSize: 12.8,
         wcagViolation: null,
@@ -481,7 +489,7 @@ describe('calculateTypeScale', () => {
     expect(result).toStrictEqual(expected);
   });
 
-  test('should generate a scale with tailwind style step labels', () => {
+  test('should generate a scale with tailwind labels', () => {
     const result = calculateTypeScale({
       minWidth: 320,
       maxWidth: 1240,
@@ -491,78 +499,87 @@ describe('calculateTypeScale', () => {
       maxTypeScale: 1.25,
       positiveSteps: 5,
       negativeSteps: 3,
-      stepLabelsStyle: 'tailwind'
+      labelStyle: 'tailwind'
     });
 
     const expected = [
       {
-        step: '4xl',
+        step: 5,
+        label: '4xl',
         minFontSize: 44.7898,
         maxFontSize: 61.0352,
         wcagViolation: null,
-        clamp: 'clamp(2.7994rem, 2.4462rem + 1.7658vi, 3.8147rem)'
+        clamp: 'clamp(2.7994rem, 2.4462rem + 1.7658vw, 3.8147rem)'
       },
       {
-        step: '3xl',
+        step: 4,
+        label: '3xl',
         minFontSize: 37.3248,
         maxFontSize: 48.8281,
         wcagViolation: null,
-        clamp: 'clamp(2.3328rem, 2.0827rem + 1.2504vi, 3.0518rem)'
+        clamp: 'clamp(2.3328rem, 2.0827rem + 1.2504vw, 3.0518rem)'
       },
       {
-        step: '2xl',
+        step: 3,
+        label: '2xl',
         minFontSize: 31.104,
         maxFontSize: 39.0625,
         wcagViolation: null,
-        clamp: 'clamp(1.944rem, 1.771rem + 0.8651vi, 2.4414rem)'
+        clamp: 'clamp(1.944rem, 1.771rem + 0.8651vw, 2.4414rem)'
       },
       {
-        step: 'xl',
+        step: 2,
+        label: 'xl',
         minFontSize: 25.92,
         maxFontSize: 31.25,
         wcagViolation: null,
-        clamp: 'clamp(1.62rem, 1.5041rem + 0.5793vi, 1.9531rem)'
+        clamp: 'clamp(1.62rem, 1.5041rem + 0.5793vw, 1.9531rem)'
       },
       {
-        step: 'lg',
+        step: 1,
+        label: 'lg',
         minFontSize: 21.6,
         maxFontSize: 25,
         wcagViolation: null,
-        clamp: 'clamp(1.35rem, 1.2761rem + 0.3696vi, 1.5625rem)'
+        clamp: 'clamp(1.35rem, 1.2761rem + 0.3696vw, 1.5625rem)'
       },
       {
-        step: 'base',
+        step: 0,
+        label: 'base',
         minFontSize: 18,
         maxFontSize: 20,
         wcagViolation: null,
-        clamp: 'clamp(1.125rem, 1.0815rem + 0.2174vi, 1.25rem)'
+        clamp: 'clamp(1.125rem, 1.0815rem + 0.2174vw, 1.25rem)'
       },
       {
-        step: 'sm',
+        step: -1,
+        label: 'sm',
         minFontSize: 15,
         maxFontSize: 16,
         wcagViolation: null,
-        clamp: 'clamp(0.9375rem, 0.9158rem + 0.1087vi, 1rem)'
+        clamp: 'clamp(0.9375rem, 0.9158rem + 0.1087vw, 1rem)'
       },
       {
-        step: 'xs',
+        step: -2,
+        label: 'xs',
         minFontSize: 12.5,
         maxFontSize: 12.8,
         wcagViolation: null,
-        clamp: 'clamp(0.7813rem, 0.7747rem + 0.0326vi, 0.8rem)'
+        clamp: 'clamp(0.7813rem, 0.7747rem + 0.0326vw, 0.8rem)'
       },
       {
-        step: '2xs',
+        step: -3,
+        label: '2xs',
         minFontSize: 10.4167,
         maxFontSize: 10.24,
         wcagViolation: null,
-        clamp: 'clamp(0.64rem, 0.6549rem + -0.0192vi, 0.651rem)'
+        clamp: 'clamp(0.64rem, 0.6549rem + -0.0192vw, 0.651rem)'
       }
     ];
     expect(result).toStrictEqual(expected);
   });
 
-  test('should generate a scale with tshirt size style step labels', () => {
+  test('should generate a scale with tshirt labels', () => {
     const result = calculateTypeScale({
       minWidth: 320,
       maxWidth: 1240,
@@ -572,72 +589,81 @@ describe('calculateTypeScale', () => {
       maxTypeScale: 1.25,
       positiveSteps: 5,
       negativeSteps: 3,
-      stepLabelsStyle: 'tshirt'
+      labelStyle: 'tshirt'
     });
 
     const expected = [
       {
-        step: '4xl',
+        step: 5,
+        label: '4xl',
         minFontSize: 44.7898,
         maxFontSize: 61.0352,
         wcagViolation: null,
-        clamp: 'clamp(2.7994rem, 2.4462rem + 1.7658vi, 3.8147rem)'
+        clamp: 'clamp(2.7994rem, 2.4462rem + 1.7658vw, 3.8147rem)'
       },
       {
-        step: '3xl',
+        step: 4,
+        label: '3xl',
         minFontSize: 37.3248,
         maxFontSize: 48.8281,
         wcagViolation: null,
-        clamp: 'clamp(2.3328rem, 2.0827rem + 1.2504vi, 3.0518rem)'
+        clamp: 'clamp(2.3328rem, 2.0827rem + 1.2504vw, 3.0518rem)'
       },
       {
-        step: '2xl',
+        step: 3,
+        label: '2xl',
         minFontSize: 31.104,
         maxFontSize: 39.0625,
         wcagViolation: null,
-        clamp: 'clamp(1.944rem, 1.771rem + 0.8651vi, 2.4414rem)'
+        clamp: 'clamp(1.944rem, 1.771rem + 0.8651vw, 2.4414rem)'
       },
       {
-        step: 'xl',
+        step: 2,
+        label: 'xl',
         minFontSize: 25.92,
         maxFontSize: 31.25,
         wcagViolation: null,
-        clamp: 'clamp(1.62rem, 1.5041rem + 0.5793vi, 1.9531rem)'
+        clamp: 'clamp(1.62rem, 1.5041rem + 0.5793vw, 1.9531rem)'
       },
       {
-        step: 'l',
+        step: 1,
+        label: 'l',
         minFontSize: 21.6,
         maxFontSize: 25,
         wcagViolation: null,
-        clamp: 'clamp(1.35rem, 1.2761rem + 0.3696vi, 1.5625rem)'
+        clamp: 'clamp(1.35rem, 1.2761rem + 0.3696vw, 1.5625rem)'
       },
       {
-        step: 'm',
+        step: 0,
+        label: 'm',
         minFontSize: 18,
         maxFontSize: 20,
         wcagViolation: null,
-        clamp: 'clamp(1.125rem, 1.0815rem + 0.2174vi, 1.25rem)'
+        clamp: 'clamp(1.125rem, 1.0815rem + 0.2174vw, 1.25rem)'
       },
       {
-        step: 's',
+        step: -1,
+        label: 's',
         minFontSize: 15,
         maxFontSize: 16,
         wcagViolation: null,
-        clamp: 'clamp(0.9375rem, 0.9158rem + 0.1087vi, 1rem)'
+        clamp: 'clamp(0.9375rem, 0.9158rem + 0.1087vw, 1rem)'
       },
       {
-        step: 'xs',
+        step: -2,
+        label: 'xs',
         minFontSize: 12.5,
         maxFontSize: 12.8,
         wcagViolation: null,
-        clamp: 'clamp(0.7813rem, 0.7747rem + 0.0326vi, 0.8rem)'
+        clamp: 'clamp(0.7813rem, 0.7747rem + 0.0326vw, 0.8rem)'
       },
       {
-        step: '2xs',
+        step: -3,
+        label: '2xs',
         minFontSize: 10.4167,
         maxFontSize: 10.24,
         wcagViolation: null,
-        clamp: 'clamp(0.64rem, 0.6549rem + -0.0192vi, 0.651rem)'
+        clamp: 'clamp(0.64rem, 0.6549rem + -0.0192vw, 0.651rem)'
       }
     ];
     expect(result).toStrictEqual(expected);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -7,25 +7,25 @@ const logObject = (a: unknown) => console.dir(a, { depth: 4 });
 describe('calculateClamp', () => {
 
   test('should generate a single clamp function', () => {
-    const result = calculateClamp({ minSize: 16, maxSize: 32, minWidth: 320, maxWidth: 1240 });    
+    const result = calculateClamp({ minSize: 16, maxSize: 32, minWidth: 320, maxWidth: 1240 });
     const expected = 'clamp(1rem, 0.6522rem + 1.7391vi, 2rem)';
     expect(result).toEqual(expected);
   });
 
   test('should generate a px clamp function', () => {
-    const result = calculateClamp({ minSize: 16, maxSize: 32, minWidth: 320, maxWidth: 1240, usePx: true });    
+    const result = calculateClamp({ minSize: 16, maxSize: 32, minWidth: 320, maxWidth: 1240, usePx: true });
     const expected = 'clamp(16px, 10.4348px + 1.7391vi, 32px)';
     expect(result).toEqual(expected);
   });
 
   test('should generate a cqi clamp function', () => {
-    const result = calculateClamp({ minSize: 16, maxSize: 32, minWidth: 320, maxWidth: 1240, relativeTo: 'container' });    
+    const result = calculateClamp({ minSize: 16, maxSize: 32, minWidth: 320, maxWidth: 1240, relativeTo: 'container' });
     const expected = 'clamp(1rem, 0.6522rem + 1.7391cqi, 2rem)';
     expect(result).toEqual(expected);
   });
 
   test('should generate a vw clamp function', () => {
-    const result = calculateClamp({ minSize: 16, maxSize: 32, minWidth: 320, maxWidth: 1240, relativeTo: 'viewport-width' });    
+    const result = calculateClamp({ minSize: 16, maxSize: 32, minWidth: 320, maxWidth: 1240, relativeTo: 'viewport-width' });
     const expected = 'clamp(1rem, 0.6522rem + 1.7391vw, 2rem)';
     expect(result).toEqual(expected);
   });
@@ -475,6 +475,168 @@ describe('calculateTypeScale', () => {
         maxFontSize: 12.8,
         wcagViolation: null,
         clamp: 'clamp(0.7813rem, 0.7747rem + 0.0326vi, 0.8rem)'
+      }
+    ];
+    expect(result).toStrictEqual(expected);
+  });
+
+  test('should generate a scale with tailwind style step labels', () => {
+    const result = calculateTypeScale({
+      minWidth: 320,
+      maxWidth: 1240,
+      minFontSize: 18,
+      maxFontSize: 20,
+      minTypeScale: 1.2,
+      maxTypeScale: 1.25,
+      positiveSteps: 5,
+      negativeSteps: 3,
+      stepLabelsStyle: 'tailwind'
+    });
+
+    const expected = [
+      {
+        step: '4xl',
+        minFontSize: 44.7898,
+        maxFontSize: 61.0352,
+        wcagViolation: null,
+        clamp: 'clamp(2.7994rem, 2.4462rem + 1.7658vi, 3.8147rem)'
+      },
+      {
+        step: '3xl',
+        minFontSize: 37.3248,
+        maxFontSize: 48.8281,
+        wcagViolation: null,
+        clamp: 'clamp(2.3328rem, 2.0827rem + 1.2504vi, 3.0518rem)'
+      },
+      {
+        step: '2xl',
+        minFontSize: 31.104,
+        maxFontSize: 39.0625,
+        wcagViolation: null,
+        clamp: 'clamp(1.944rem, 1.771rem + 0.8651vi, 2.4414rem)'
+      },
+      {
+        step: 'xl',
+        minFontSize: 25.92,
+        maxFontSize: 31.25,
+        wcagViolation: null,
+        clamp: 'clamp(1.62rem, 1.5041rem + 0.5793vi, 1.9531rem)'
+      },
+      {
+        step: 'lg',
+        minFontSize: 21.6,
+        maxFontSize: 25,
+        wcagViolation: null,
+        clamp: 'clamp(1.35rem, 1.2761rem + 0.3696vi, 1.5625rem)'
+      },
+      {
+        step: 'base',
+        minFontSize: 18,
+        maxFontSize: 20,
+        wcagViolation: null,
+        clamp: 'clamp(1.125rem, 1.0815rem + 0.2174vi, 1.25rem)'
+      },
+      {
+        step: 'sm',
+        minFontSize: 15,
+        maxFontSize: 16,
+        wcagViolation: null,
+        clamp: 'clamp(0.9375rem, 0.9158rem + 0.1087vi, 1rem)'
+      },
+      {
+        step: 'xs',
+        minFontSize: 12.5,
+        maxFontSize: 12.8,
+        wcagViolation: null,
+        clamp: 'clamp(0.7813rem, 0.7747rem + 0.0326vi, 0.8rem)'
+      },
+      {
+        step: '2xs',
+        minFontSize: 10.4167,
+        maxFontSize: 10.24,
+        wcagViolation: null,
+        clamp: 'clamp(0.64rem, 0.6549rem + -0.0192vi, 0.651rem)'
+      }
+    ];
+    expect(result).toStrictEqual(expected);
+  });
+
+  test('should generate a scale with tshirt size style step labels', () => {
+    const result = calculateTypeScale({
+      minWidth: 320,
+      maxWidth: 1240,
+      minFontSize: 18,
+      maxFontSize: 20,
+      minTypeScale: 1.2,
+      maxTypeScale: 1.25,
+      positiveSteps: 5,
+      negativeSteps: 3,
+      stepLabelsStyle: 'tshirt'
+    });
+
+    const expected = [
+      {
+        step: '4xl',
+        minFontSize: 44.7898,
+        maxFontSize: 61.0352,
+        wcagViolation: null,
+        clamp: 'clamp(2.7994rem, 2.4462rem + 1.7658vi, 3.8147rem)'
+      },
+      {
+        step: '3xl',
+        minFontSize: 37.3248,
+        maxFontSize: 48.8281,
+        wcagViolation: null,
+        clamp: 'clamp(2.3328rem, 2.0827rem + 1.2504vi, 3.0518rem)'
+      },
+      {
+        step: '2xl',
+        minFontSize: 31.104,
+        maxFontSize: 39.0625,
+        wcagViolation: null,
+        clamp: 'clamp(1.944rem, 1.771rem + 0.8651vi, 2.4414rem)'
+      },
+      {
+        step: 'xl',
+        minFontSize: 25.92,
+        maxFontSize: 31.25,
+        wcagViolation: null,
+        clamp: 'clamp(1.62rem, 1.5041rem + 0.5793vi, 1.9531rem)'
+      },
+      {
+        step: 'l',
+        minFontSize: 21.6,
+        maxFontSize: 25,
+        wcagViolation: null,
+        clamp: 'clamp(1.35rem, 1.2761rem + 0.3696vi, 1.5625rem)'
+      },
+      {
+        step: 'm',
+        minFontSize: 18,
+        maxFontSize: 20,
+        wcagViolation: null,
+        clamp: 'clamp(1.125rem, 1.0815rem + 0.2174vi, 1.25rem)'
+      },
+      {
+        step: 's',
+        minFontSize: 15,
+        maxFontSize: 16,
+        wcagViolation: null,
+        clamp: 'clamp(0.9375rem, 0.9158rem + 0.1087vi, 1rem)'
+      },
+      {
+        step: 'xs',
+        minFontSize: 12.5,
+        maxFontSize: 12.8,
+        wcagViolation: null,
+        clamp: 'clamp(0.7813rem, 0.7747rem + 0.0326vi, 0.8rem)'
+      },
+      {
+        step: '2xs',
+        minFontSize: 10.4167,
+        maxFontSize: 10.24,
+        wcagViolation: null,
+        clamp: 'clamp(0.64rem, 0.6549rem + -0.0192vi, 0.651rem)'
       }
     ];
     expect(result).toStrictEqual(expected);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 // Types
 
 type UtopiaRelativeTo = 'viewport' | 'container' | 'viewport-width';
+type UtopiaStepLabelStyle = 'utopia' | 'tailwind' | 'tshirt';
 
 export type UtopiaTypeConfig = {
   minWidth: number;
@@ -12,10 +13,11 @@ export type UtopiaTypeConfig = {
   negativeSteps?: number;
   positiveSteps?: number;
   relativeTo?: UtopiaRelativeTo;
+  stepLabelsStyle?: UtopiaStepLabelStyle
 }
 
 export type UtopiaStep = {
-  step: number;
+  step: string | number;
   minFontSize: number;
   maxFontSize: number;
   wcagViolation?: {
@@ -187,13 +189,41 @@ const calculateTypeSize = (config: UtopiaTypeConfig, viewport: number, step: num
   return fontSize * Math.pow(scale, step);
 }
 
+
+const mapStepToLabel = (step: number, labelGroup: UtopiaStepLabelStyle = "utopia") => {
+  if (labelGroup === "utopia") return step
+
+  let label = "";
+
+  if (step < -2) label = `${-1 * (step + 1)}xs`
+  if (step === -2) label = "xs"
+
+  if (labelGroup === "tailwind") {
+    if (step === -1) label = "sm"
+    if (step === 0) label = "base"
+    if (step === 1) label = "lg"
+  }
+
+  if (labelGroup === "tshirt") {
+    if (step === -1) label = "s"
+    if (step === 0) label = "m"
+    if (step === 1) label = "l"
+  }
+
+  if (step === 2) label = "xl"
+  if (step > 2) label = `${step - 1}xl`
+
+
+  return label;
+}
+
 const calculateTypeStep = (config: UtopiaTypeConfig, step: number): UtopiaStep => {
   const minFontSize = calculateTypeSize(config, config.minWidth, step);
   const maxFontSize = calculateTypeSize(config, config.maxWidth, step);
   const wcag = checkWCAG({ min: minFontSize, max: maxFontSize, minWidth: config.minWidth, maxWidth: config.maxWidth });
 
   return {
-    step,
+    step: mapStepToLabel(step, config.stepLabelsStyle),
     minFontSize: roundValue(minFontSize),
     maxFontSize: roundValue(maxFontSize),
     wcagViolation: wcag?.length ? {

--- a/src/index.ts
+++ b/src/index.ts
@@ -192,30 +192,27 @@ const calculateTypeSize = (config: UtopiaTypeConfig, viewport: number, step: num
 
 
 const mapStepToLabel = (step: number, labelGroup: UtopiaLabelStyle = "utopia") => {
-  if (labelGroup === "utopia") return step.toString()
+  if (labelGroup === "utopia") return step.toString();
 
-  let label = "";
-
-  if (step < -2) label = `${-1 * (step + 1)}xs`
-  if (step === -2) label = "xs"
+  if (step < -2) return `${-1 * (step + 1)}xs`;
+  if (step === -2) return "xs";
 
   if (labelGroup === "tailwind") {
-    if (step === -1) label = "sm"
-    if (step === 0) label = "base"
-    if (step === 1) label = "lg"
+    if (step === -1) return "sm";
+    if (step === 0) return "base";
+    if (step === 1) return "lg";
   }
 
   if (labelGroup === "tshirt") {
-    if (step === -1) label = "s"
-    if (step === 0) label = "m"
-    if (step === 1) label = "l"
+    if (step === -1) return "s";
+    if (step === 0) return "m";
+    if (step === 1) return "l";
   }
 
-  if (step === 2) label = "xl"
-  if (step > 2) label = `${step - 1}xl`
+  if (step === 2) return "xl";
+  if (step > 2) return `${step - 1}xl`;
 
-
-  return label;
+  return step.toString();
 }
 
 const calculateTypeStep = (config: UtopiaTypeConfig, step: number): UtopiaStep => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 // Types
 
 type UtopiaRelativeTo = 'viewport' | 'container' | 'viewport-width';
-type UtopiaStepLabelStyle = 'utopia' | 'tailwind' | 'tshirt';
+type UtopiaLabelStyle = 'utopia' | 'tailwind' | 'tshirt';
 
 export type UtopiaTypeConfig = {
   minWidth: number;
@@ -13,11 +13,12 @@ export type UtopiaTypeConfig = {
   negativeSteps?: number;
   positiveSteps?: number;
   relativeTo?: UtopiaRelativeTo;
-  stepLabelsStyle?: UtopiaStepLabelStyle
+  labelStyle?: UtopiaLabelStyle
 }
 
 export type UtopiaStep = {
-  step: string | number;
+  step: number;
+  label: string;
   minFontSize: number;
   maxFontSize: number;
   wcagViolation?: {
@@ -190,8 +191,8 @@ const calculateTypeSize = (config: UtopiaTypeConfig, viewport: number, step: num
 }
 
 
-const mapStepToLabel = (step: number, labelGroup: UtopiaStepLabelStyle = "utopia") => {
-  if (labelGroup === "utopia") return step
+const mapStepToLabel = (step: number, labelGroup: UtopiaLabelStyle = "utopia") => {
+  if (labelGroup === "utopia") return step.toString()
 
   let label = "";
 
@@ -223,7 +224,8 @@ const calculateTypeStep = (config: UtopiaTypeConfig, step: number): UtopiaStep =
   const wcag = checkWCAG({ min: minFontSize, max: maxFontSize, minWidth: config.minWidth, maxWidth: config.maxWidth });
 
   return {
-    step: mapStepToLabel(step, config.stepLabelsStyle),
+    step,
+    label: mapStepToLabel(step, config.labelStyle),
     minFontSize: roundValue(minFontSize),
     maxFontSize: roundValue(maxFontSize),
     wcagViolation: wcag?.length ? {


### PR DESCRIPTION
Opening up this discussion about implementing custom step labels  as mentioned here #6. How are we feeling about something like this?

## Approach


Added a new parameter to `calculateTypeSize` config 

```typescript

type UtopiaTypeConfig = {
  ...,
  labelStyle?: "utopia" | "tailwind" | "tshirt"; // defaults to "utopia"
}

```


Which then maps the scale steps to it's corresponding label according to this table:


| Scale    |     |     |     |     |      |     |     |     |     |
| -------- | --- | --- | --- | --- | ---- | --- | --- | --- | --- |
| `utopia`   | -N  | -3  | -2  | -1  | 0    | 1   | 2   | 3   | N   |
| `tailwind` | Nxs | 2xs | xs  | sm  | base | lg  | xl  | 2xl | Nxl |
| `tshirt`    | Nxs | 2xs | xs  | s   | m    | l   | xl  | 2xl | Nxl |


which ultimately produces the following scale array

```diff

// Using labelStyle: 'tailwind'

{
  step: -1,
+ label: 'sm',
  minFontSize: 44.7898,
  maxFontSize: 61.0352,
  wcagViolation: null,
  clamp: 'clamp(2.7994rem, 2.4462rem + 1.7658vi, 3.8147rem)'
},
{
  step: 0,
+ label: 'base',
  ...
},
{
  step: 1,
+ label: 'lg',
  ...
}

```


```diff

// Using labelStyle: 'tshirt'

{
  step: -1,
+ label: 's',
  ...
},
{
  step: 0,
+ label: 'm',
  ...
},
{
  step: 1,
+ label: 'l',
  ...
}
```


## Todo

- [x] Custom labels for type scales
- [ ] Custom labels for space scales

I am yet to explore how this can be applied to the spacing scale. I think it is going to be slightly more involved because of how the `oneUpPairs` and `customPairs` work.